### PR TITLE
Update copyright owner to 2025 NEAR Foundation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "one-click-sdk-rs"
 version = "0.1.10"
-authors = ["OpenAPI Generator team and contributors"]
+authors = ["2025 NEAR Foundation"]
 description = "API for One-Click Swaps"
 # Override this license by providing a License Object in the OpenAPI.
 license = "Unlicense"

--- a/README.md
+++ b/README.md
@@ -55,5 +55,5 @@ cargo doc --open
 
 ## Author
 
-
+© 2025 NEAR Foundation
 

--- a/v0/Cargo.toml
+++ b/v0/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "oneclick"
 version = "0.1.10"
-authors = ["OpenAPI Generator team and contributors"]
+authors = ["2025 NEAR Foundation"]
 description = "API for One-Click Swaps"
 # Override this license by providing a License Object in the OpenAPI.
 license = "Unlicense"

--- a/v0/README.md
+++ b/v0/README.md
@@ -55,5 +55,5 @@ cargo doc --open
 
 ## Author
 
-
+© 2025 NEAR Foundation
 


### PR DESCRIPTION
## Summary
- update crate metadata to list 2025 NEAR Foundation as the author
- document the new ownership in both README files

## Testing
- cargo fmt --check *(fails: repository contains existing formatting differences in generated files)*

------
https://chatgpt.com/codex/tasks/task_b_68cbdb6bba70832c8295d343c7a101fa

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package metadata to reflect new authorship and set the Rust edition to 2021 for current standards and tooling compatibility.
* **Documentation**
  * Added copyright attribution “© 2025 NEAR Foundation” in author sections.
  * Clarified authorship throughout the project documentation.

No functional changes or user-facing behavior updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->